### PR TITLE
toml_union.py: Check values size in process()

### DIFF
--- a/toml_union.py
+++ b/toml_union.py
@@ -159,7 +159,7 @@ def disable_lists_dict(dct: TOML_DICT) -> TOML_DICT:
         d = copy.deepcopy(data)
 
         for k, v in data.items():
-            if isinstance(v, list) and isinstance(v[0], dict):  # it is the list of dicts
+            if isinstance(v, list) and len(v) > 0 and isinstance(v[0], dict):  # it is the list of dicts
                 new_dicts = {
                     f"{k}{SEP}{item['name']}": process({_k: _v for _k, _v in item.items() if _k != 'name'})
                     for item in v


### PR DESCRIPTION
When trying to merge `Cargo.toml` files for rust we get the following traceback:
```
Traceback (most recent call last):
  File "./toml-union/myscript.py", line 7, in <module>
    toml_union_process(
  File "./toml-union/toml_union.py", line 406, in toml_union_process
    datas: DATA_DICT = union_dicts(
  File "./toml-union/toml_union.py", line 299, in union_dicts
    dicts = [
  File "./toml-union/toml_union.py", line 299, in <listcomp>
    dicts = [
  File "./toml-union/toml_union.py", line 407, in <genexpr>
    read_toml(file) for file in toml_files
  File "./toml-union/toml_union.py", line 210, in read_toml
    content = disable_lists_dict(content)
  File "./toml-union/toml_union.py", line 175, in disable_lists_dict
    return process(dct)
  File "./toml-union/toml_union.py", line 171, in process
    d[k] = process(v)
  File "./toml-union/toml_union.py", line 162, in process
    if isinstance(v, list) and isinstance(v[0], dict):  # it is the list of dicts
IndexError: list index out of range
```
Checking the values size in `process()` fixes that.