### PR TITLE
fix(kvdictAppendAction): maxsplit set to 1

### DIFF
--- a/toml_union/toml_union.py
+++ b/toml_union/toml_union.py
@@ -619,7 +619,7 @@ class kvdictAppendAction(argparse.Action):
     def __call__(self, parser, args, values, option_string=None):
         assert(len(values) == 1)
         try:
-            (k, v) = values[0].split("=", 2)
+            (k, v) = values[0].split("=", 1)
         except ValueError as ex:
             raise argparse.ArgumentError(
                 self, f"could not parse argument \"{values[0]}\" as k=v format"


### PR DESCRIPTION
- Fixes #9 

This PR sets the `maxsplit` parameter of the `split` method used in `kvdictAppendAction` to allow values such as `>=1.2.3`